### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v2
     - name: Run shellcheck tests
-      run: shellcheck fuzzy-cd setup
+      run: shellcheck fuzzycd setup
     - name: Run approval tests
       run: test/approve
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Install fzf
       run: sudo apt install -y fzf
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v2
-
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v2
     - name: Run shellcheck tests
       run: shellcheck fuzzy-cd setup
     - name: Run approval tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Install fzf
       run: sudo apt install -y fzf
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v2
+
     - name: Run shellcheck tests
       run: shellcheck fuzzy-cd setup
     - name: Run approval tests

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ instantly using a fuzzy search
 # Fuzzy CD
 
 ![Version](https://img.shields.io/badge/version-0.1.2-blue.svg)
-[![Build Status](https://github.com/DannyBen/fuzzy-cd/workflows/Test/badge.svg)](https://github.com/DannyBen/fuzzy-cd/actions?query=workflow%3ATest)
+[![Build Status](https://github.com/DannyBen/fuzzycd/workflows/Test/badge.svg)](https://github.com/DannyBen/fuzzycd/actions?query=workflow%3ATest)
 
 ## Features
 
@@ -35,19 +35,19 @@ Fuzzy CD requires a recent version of [fzf].
 
 ### Installing using the setup script
 
-This setup script will download the `fuzzy-cd` function to `~/.fuzzy-cd/` and
+This setup script will download the `fuzzycd` function to `/usr/local/bin` and
 apply the necessary `source` command to your startup script.
 
 ```shell
-$ curl -Ls get.dannyb.co/fuzzy-cd/setup | bash
+$ curl -Ls get.dannyb.co/fuzzycd/setup | bash
 ```
 
 You are encouraged to inspect the [setup script](setup) before running.
 
 ### Installing manually
 
-1. Place the `fuzzy-cd` file somewhere on your system (for example: `~/.fuzzy-cd/fuzzy-cd`)
-2. Source it (`source ~/.fuzzy-cd/fuzzy-cd`) from your startup script (for example: `~/.bashrc`)
+1. Place the `fuzzycd` file in `/usr/local/bin/` and make it executable
+2. Source it (`source /usr/local/bin/fuzzycd`) from your startup script (for example: `~/.bashrc`)
 
 
 ## Usage
@@ -65,7 +65,7 @@ will be remembered in a history file. You can view this file by running:
 ```shell
 $ cd -s
 # or
-$ cat ~/.fuzzy-cd/history
+$ cat ~/.fuzzycd-history
 ```
 
 ### Fuzzy search
@@ -84,5 +84,5 @@ to contribute, feel free to [open an issue][issues].
 
 ---
 
-[issues]: https://github.com/DannyBen/fuzzy-cd/issues
+[issues]: https://github.com/DannyBen/fuzzycd/issues
 [fzf]: https://github.com/junegunn/fzf

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Now, you can use `cd` normally to change to any directory. These directories
 will be remembered in a history file. You can view this file by running:
 
 ```shell
-$ cat ~/.fuzzy-cd-history
+$ cd -s
+# or
+$ cat ~/.fuzzy-cd/history
 ```
 
 ### Fuzzy search

--- a/demo/demo-maker.ahk
+++ b/demo/demo-maker.ahk
@@ -7,7 +7,7 @@ SetkeyDelay 0, 50
 ; NOTES TO SELF:
 ;
 ;   1. ESC == EMERGENCY ABORT
-;   2. Starting point should be the root fuzzy-cd directory
+;   2. Starting point should be the root fuzzycd directory
 ;   3. This is the prompt we are using. Put it in ~/.bashrc.d/prompt.bashrc
 ;      PS1="\n\[\e[0;35m\]\h \[\e[1;34m\]\w \[\e[1;32m\]➜\[\e[0m\] "
 ;   4. Recorded in a half tmux panel

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -84,7 +84,7 @@ cd() {
     dir="${1:-$PWD}"
     grep -v "$dir" "$histfile" > "$HOME/.fuzzy-cd/history.tmp" &&\
       cp "$HOME/.fuzzy-cd/history.tmp" "$histfile" &&\
-      rm "$HOME/.fuzzy-cd/history.tmp" &&\
+      rm -f "$HOME/.fuzzy-cd/history.tmp" &&\
       echo "deleted $dir"
   }
 

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -12,7 +12,7 @@ fi
 unalias cd 2> /dev/null
 cd() {
   local version="0.1.2"
-  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzy-cd-history"}
+  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzy-cd/history"}
 
   _fzcd_is_dirname() {
     if [[ -d "$1" ]]; then
@@ -45,6 +45,10 @@ cd() {
     grep -qxF "$PWD" "$histfile" || echo "$PWD" >> "$histfile"
   }
 
+  _fzcd_create_histfile() {
+    mkdir -p "$(dirname "$histfile")" && touch "$histfile";
+  }
+
   _fzcd_chdir() {
     builtin cd "$@" && _fzcd_remember_me
   }
@@ -68,6 +72,11 @@ cd() {
 
   _fzcd_show_version() {
     echo "fuzzy-cd $version"
+  }
+
+  _fzcd_delete_dir() {
+    dir="${1:-$PWD}"
+    echo $dir
   }
 
   _fzcd_show_usage() {
@@ -94,13 +103,14 @@ cd() {
   }
 
   _fzcd_run() {
-    [[ -f "$histfile" ]] || touch "$histfile"
+    [[ -f "$histfile" ]] || _fzcd_create_histfile
 
     case "$1" in
       "-l" ) _fzcd_chdir_fzf ;;
       "-v" ) _fzcd_show_version ;;
       "-e" ) _fzcd_edit_histfile ;;
       "-s" ) _fzcd_show_histfile ;;
+      # "-d" ) _fzcd_delete_dir ;;
       "-h" ) _fzcd_show_usage ;;
       *    ) _fzcd_handle_command "$@" ;;
     esac

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -82,11 +82,7 @@ cd() {
 
   _fzcd_delete_dir() {
     dir="${1:-$PWD}"
-
-    while read -r line; do
-      [[ "$line" != "$dir" ]] && echo "$line"
-    done <"$histfile" > "$HOME/.fuzzy-cd/history.tmp"
-
+    grep -v "$dir" "$histfile" > "$HOME/.fuzzy-cd/history.tmp"
     cp "$HOME/.fuzzy-cd/history.tmp" "$histfile"
     rm -f "$HOME/.fuzzy-cd/history.tmp"
     echo "deleted $dir"

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -35,11 +35,19 @@ cd() {
   _fzcd_run_fzf() {
     # shellcheck disable=SC2145
     
-    # interactive-on-multi
-    fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd " --preview='ls {}' --preview-window="border-left"
-    
-    # non-interactive
-    # fzf --filter "$@" --exit-0 | head -1
+    case "$FUZZYCD_MODE" in
+      "-interactive" )
+        fzf --filter "$@" --exit-0 | head -1
+        ;;
+
+      "-preview" )
+        fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd "
+        ;;
+
+      * )
+        fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd " --preview='ls {}' --preview-window="border-left"
+        ;;
+    esac
   }
 
   _fzcd_dir_search() {
@@ -104,6 +112,9 @@ cd() {
     echo "Environment Variables:"
     echo "  FUZZYCD_HISTORY_FILE"
     echo "    Path to history file [default: ~/.fuzzy-cd/history"
+    echo ""
+    echo "  FUZZYCD_MODE"
+    echo "    Set mode to one of (default, non-interactive, no-preview)"
   }
 
   _fzcd_handle_command() {

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -82,10 +82,14 @@ cd() {
 
   _fzcd_delete_dir() {
     dir="${1:-$PWD}"
-    grep -v "$dir" "$histfile" > "$HOME/.fuzzy-cd/history.tmp" &&\
-      cp "$HOME/.fuzzy-cd/history.tmp" "$histfile" &&\
-      rm -f "$HOME/.fuzzy-cd/history.tmp" &&\
-      echo "deleted $dir"
+
+    while read -r line; do
+      [[ "$line" != "$dir" ]] && echo "$line"
+    done <"$histfile" > "$HOME/.fuzzy-cd/history.tmp"
+
+    cp "$HOME/.fuzzy-cd/history.tmp" "$histfile"
+    rm -f "$HOME/.fuzzy-cd/history.tmp"
+    echo "deleted $dir"
   }
 
   _fzcd_show_usage() {

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -71,7 +71,7 @@ cd() {
     if [[ -n $target ]]; then
       _fzcd_chdir "$target"
       echo "$target"
-    else
+    elif [[ -n "$@" ]]; then
       _fzcd_chdir "$@"
     fi
   }

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -71,7 +71,7 @@ cd() {
     if [[ -n $target ]]; then
       _fzcd_chdir "$target"
       echo "$target"
-    elif [[ -n "$@" ]]; then
+    elif [[ -n "$1" ]]; then
       _fzcd_chdir "$@"
     fi
   }

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -34,7 +34,12 @@ cd() {
 
   _fzcd_run_fzf() {
     # shellcheck disable=SC2145
+    
+    # interactive-on-multi
     fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd " --preview='ls {}' --preview-window="border-left"
+    
+    # non-interactive
+    # fzf --filter "$@" --exit-0 | head -1
   }
 
   _fzcd_dir_search() {
@@ -95,6 +100,10 @@ cd() {
     echo "  cd -d [DIR]  remove current or specified directory from history"
     echo "  cd -v        show version"
     echo "  cd -h        show this help"
+    echo ""
+    echo "Environment Variables:"
+    echo "  FUZZYCD_HISTORY_FILE"
+    echo "    Path to history file [default: ~/.fuzzy-cd/history"
   }
 
   _fzcd_handle_command() {

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -57,6 +57,7 @@ cd() {
     target=$(_fzcd_dir_search "$@")
     if [[ -n $target ]]; then
       _fzcd_chdir "$target"
+      echo "$target"
     else
       _fzcd_chdir "$@"
     fi
@@ -76,7 +77,10 @@ cd() {
 
   _fzcd_delete_dir() {
     dir="${1:-$PWD}"
-    echo $dir
+    grep -v "$dir" "$histfile" > "$HOME/.fuzzy-cd/history.tmp" &&\
+      cp "$HOME/.fuzzy-cd/history.tmp" "$histfile" &&\
+      rm "$HOME/.fuzzy-cd/history.tmp" &&\
+      echo "deleted $dir"
   }
 
   _fzcd_show_usage() {
@@ -88,6 +92,7 @@ cd() {
     echo "  cd -l        list history with fzf"
     echo "  cd -e        edit history file"
     echo "  cd -s        show history file"
+    echo "  cd -d [DIR]  remove current or specified directory from history"
     echo "  cd -v        show version"
     echo "  cd -h        show this help"
   }
@@ -110,7 +115,7 @@ cd() {
       "-v" ) _fzcd_show_version ;;
       "-e" ) _fzcd_edit_histfile ;;
       "-s" ) _fzcd_show_histfile ;;
-      # "-d" ) _fzcd_delete_dir ;;
+      "-d" ) shift ; _fzcd_delete_dir "$@" ;;
       "-h" ) _fzcd_show_usage ;;
       *    ) _fzcd_handle_command "$@" ;;
     esac

--- a/fuzzy-cd
+++ b/fuzzy-cd
@@ -36,11 +36,11 @@ cd() {
     # shellcheck disable=SC2145
     
     case "$FUZZYCD_MODE" in
-      "-interactive" )
+      "non-interactive" )
         fzf --filter "$@" --exit-0 | head -1
         ;;
 
-      "-preview" )
+      "no-preview" )
         fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd "
         ;;
 

--- a/fuzzycd
+++ b/fuzzycd
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
 
-# If not running interactively, don't do anything
-# Bypass by setting FUZZYCD_TTY_FORCE
-if [[ -z "$FUZZYCD_TTY_FORCE" ]]; then
-  case $- in
-    *i*) ;;
-    *) return;;
-  esac
-fi
-
-unalias cd 2> /dev/null
-cd() {
-  local version="0.1.2"
-  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzy-cd/history"}
+fuzzycd_run() {
+  local version="0.2.0"
+  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}
 
   _fzcd_is_dirname() {
     if [[ -d "$1" ]]; then
@@ -41,11 +31,11 @@ cd() {
         ;;
 
       "no-preview" )
-        fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd "
+        fzf --query="$@" --bind="del:execute-silent(fuzzycd -d {})+reload(fuzzycd -s)" --select-1 --exit-0 --info=hidden --prompt="➜ cd "
         ;;
 
       * )
-        fzf --query="$@" --select-1 --exit-0 --info=hidden --prompt="➜ cd " --preview='ls {}' --preview-window="border-left"
+        fzf --query="$@" --bind="del:execute-silent(fuzzycd -d {})+reload(fuzzycd -s)" --select-1 --exit-0 --info=hidden --prompt="➜ cd " --preview='ls {}' --preview-window="border-left"
         ;;
     esac
   }
@@ -85,14 +75,14 @@ cd() {
   }
 
   _fzcd_show_version() {
-    echo "fuzzy-cd $version"
+    echo "fuzzycd $version"
   }
 
   _fzcd_delete_dir() {
     dir="${1:-$PWD}"
-    grep -v "$dir" "$histfile" > "$HOME/.fuzzy-cd/history.tmp"
-    cp "$HOME/.fuzzy-cd/history.tmp" "$histfile"
-    rm -f "$HOME/.fuzzy-cd/history.tmp"
+    grep -Fxv "$dir" "$histfile" > "$HOME/.fuzzycd-history.tmp"
+    cp "$HOME/.fuzzycd-history.tmp" "$histfile"
+    rm -f "$HOME/.fuzzycd-history.tmp"
     echo "deleted $dir"
   }
 
@@ -111,10 +101,14 @@ cd() {
     echo ""
     echo "Environment Variables:"
     echo "  FUZZYCD_HISTORY_FILE"
-    echo "    Path to history file [default: ~/.fuzzy-cd/history"
+    echo "    Path to history file [default: ~/.fuzzycd-history"
     echo ""
     echo "  FUZZYCD_MODE"
     echo "    Set mode to one of (default, non-interactive, no-preview)"
+    echo ""
+    echo "Interactive Keyboard Bindings:"
+    echo "  Del"
+    echo "    Delete selected directory from history"
   }
 
   _fzcd_handle_command() {
@@ -143,3 +137,22 @@ cd() {
 
   _fzcd_run "$@"
 }
+
+# shellcheck disable=SC2015
+(return 0 2>/dev/null) && is_sourced=1 || fuzzycd_run "$@"
+
+if [[ -n "$is_sourced" ]]; then
+  # If not running interactively, don't do anything
+  # Bypass by setting FUZZYCD_TTY_FORCE
+  if [[ -z "$FUZZYCD_TTY_FORCE" ]]; then
+    case $- in
+      *i*) ;;
+      *) return;;
+    esac
+  fi
+
+  unalias cd 2> /dev/null || true
+  cd() {
+    fuzzycd_run "$@";
+  }
+fi

--- a/op.conf
+++ b/op.conf
@@ -1,3 +1,2 @@
-shellcheck: shellcheck setup fuzzy-cd
-cp: cp fuzzy-cd ~/.fuzzy-cd/
+shellcheck: shellcheck setup fuzzycd
 test: test/approve

--- a/setup
+++ b/setup
@@ -47,7 +47,6 @@ fuzzy_cd_setup() {
   download_script
   patch_startup_files
   show_exit_message
-  fuzzycd -v
 }
 
 fuzzy_cd_setup

--- a/setup
+++ b/setup
@@ -5,19 +5,26 @@ fuzzy_cd_setup() {
 
   patch_file() {
     file="$1"
-    if grep -q .fuzzy-cd/fuzzy-cd "$file"; then
+    if grep -q fuzzycd "$file"; then
       echo "=== Skipping $file"
     else
       echo "=== Amending $file"
-      printf "source ~/.fuzzy-cd/fuzzy-cd\n" >> "$file"
+      printf "source /usr/local/bin\n" >> "$file"
     fi
     patched="yes"
   }
 
   download_script() {
-    echo "=== Saving fuzzy-cd to ~/.fuzzy-cd/"
-    mkdir -p "$HOME/.fuzzy-cd"
-    curl -s https://raw.githubusercontent.com/DannyBen/fuzzy-cd/master/fuzzy-cd > "$HOME/.fuzzy-cd/fuzzy-cd"
+    echo "=== Saving fuzzycd to /usr/local/bin"
+    
+    sudo=''
+    if [[ $EUID -ne 0 ]]; then
+      sudo='sudo'
+    fi
+
+    curl_command="curl -s https://raw.githubusercontent.com/DannyBen/fuzzycd/master/fuzzycd > /usr/local/bin/fuzzycd"
+    $sudo bash -c "$curl_command"
+    $sudo chmod a+x /usr/local/bin/fuzzycd
   }
 
   patch_startup_files() {
@@ -40,6 +47,7 @@ fuzzy_cd_setup() {
   download_script
   patch_startup_files
   show_exit_message
+  fuzzycd -v
 }
 
 fuzzy_cd_setup

--- a/test/approvals.bash
+++ b/test/approvals.bash
@@ -1,4 +1,4 @@
-# approvals.bash v0.3.1
+# approvals.bash v0.3.2
 #
 # Interactive approval testing for Bash.
 # https://github.com/DannyBen/approvals.bash
@@ -101,8 +101,13 @@ onexit() {
   exit $exitcode
 }
 
+onerror() {
+  fail "Caller: $(caller)"
+}
+
 set -e
 trap 'onexit' EXIT
+trap 'onerror' ERR
 
 if diff --help | grep -- --color > /dev/null 2>&1; then
   diff_cmd="diff --unified --color=always"

--- a/test/approvals/cd_d
+++ b/test/approvals/cd_d
@@ -1,0 +1,1 @@
+deleted /usr/local/lib

--- a/test/approvals/cd_d_etc
+++ b/test/approvals/cd_d_etc
@@ -1,0 +1,1 @@
+deleted /etc

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -13,3 +13,6 @@ Usage:
 Environment Variables:
   FUZZYCD_HISTORY_FILE
     Path to history file [default: ~/.fuzzy-cd/history
+
+  FUZZYCD_MODE
+    Set mode to one of (default, non-interactive, no-preview)

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -6,5 +6,6 @@ Usage:
   cd -l        list history with fzf
   cd -e        edit history file
   cd -s        show history file
+  cd -d [DIR]  remove current or specified directory from history
   cd -v        show version
   cd -h        show this help

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -1,4 +1,4 @@
-fuzzy-cd 0.1.2
+fuzzycd 0.2.0
 
 Usage:
   cd DIR       change working directory
@@ -12,7 +12,11 @@ Usage:
 
 Environment Variables:
   FUZZYCD_HISTORY_FILE
-    Path to history file [default: ~/.fuzzy-cd/history
+    Path to history file [default: ~/.fuzzycd-history
 
   FUZZYCD_MODE
     Set mode to one of (default, non-interactive, no-preview)
+
+Interactive Keyboard Bindings:
+  Del
+    Delete selected directory from history

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -9,3 +9,7 @@ Usage:
   cd -d [DIR]  remove current or specified directory from history
   cd -v        show version
   cd -h        show this help
+
+Environment Variables:
+  FUZZYCD_HISTORY_FILE
+    Path to history file [default: ~/.fuzzy-cd/history

--- a/test/approvals/cd_localb
+++ b/test/approvals/cd_localb
@@ -1,0 +1,1 @@
+/usr/local/bin

--- a/test/approvals/cd_s
+++ b/test/approvals/cd_s
@@ -1,2 +1,3 @@
 /usr/local/bin
+/usr/local/lib
 /etc

--- a/test/approvals/cd_s_after_delete
+++ b/test/approvals/cd_s_after_delete
@@ -1,3 +1,2 @@
 /usr/local/bin
 /usr/local/lib
-/etc

--- a/test/approvals/cd_s_after_delete2
+++ b/test/approvals/cd_s_after_delete2
@@ -1,0 +1,1 @@
+/usr/local/bin

--- a/test/approvals/cd_v
+++ b/test/approvals/cd_v
@@ -1,1 +1,1 @@
-fuzzy-cd 0.1.2
+fuzzycd 0.2.0

--- a/test/approve
+++ b/test/approve
@@ -67,3 +67,18 @@ context "when the history file contains some entries"
   cd "$basedir"
   rm -f "$FUZZYCD_HISTORY_FILE"  
 
+
+context "when the FUZZYCD_MODE=non-interactive"
+
+  export FUZZYCD_MODE=non-interactive
+  rm -f "$FUZZYCD_HISTORY_FILE"
+  cd /usr/local/bin > /dev/null
+  cd /usr/local/lib > /dev/null
+
+  describe "cd with a fuzzy string goes to bes match"
+    approve "cd localb"
+
+  cd "$basedir"
+  rm -f "$FUZZYCD_HISTORY_FILE"
+  unset FUZZYCD_MODE
+

--- a/test/approve
+++ b/test/approve
@@ -9,6 +9,7 @@ source ../fuzzy-cd
 export FUZZYCD_HISTORY_FILE="$PWD/tmp/histfile"
 rm -f "$FUZZYCD_HISTORY_FILE"
 mkdir -p tmp/one/two
+mkdir -p "$HOME/.fuzzy-cd"
 
 context "when the shell is non-interactive"
 

--- a/test/approve
+++ b/test/approve
@@ -5,11 +5,11 @@ export APPROVALS_DIR="$PWD/approvals"
 source approvals.bash
 
 basedir="$PWD"
-source ../fuzzy-cd
+source ../fuzzycd
 export FUZZYCD_HISTORY_FILE="$PWD/tmp/histfile"
 rm -f "$FUZZYCD_HISTORY_FILE"
 mkdir -p tmp/one/two
-mkdir -p "$HOME/.fuzzy-cd"
+mkdir -p "$HOME/.fuzzycd"
 
 context "when the shell is non-interactive"
 
@@ -20,7 +20,7 @@ context "when the shell is non-interactive"
 context "when the shell is interactive"
 
   export FUZZYCD_TTY_FORCE=1
-  source ../fuzzy-cd || return 0
+  source ../fuzzycd
 
   describe "cd is a function"
     approve "type -t cd" "type_function"
@@ -68,7 +68,7 @@ context "when the history file contains some entries"
   rm -f "$FUZZYCD_HISTORY_FILE"  
 
 
-context "when the FUZZYCD_MODE=non-interactive"
+context "when FUZZYCD_MODE=non-interactive"
 
   export FUZZYCD_MODE=non-interactive
   rm -f "$FUZZYCD_HISTORY_FILE"
@@ -81,4 +81,3 @@ context "when the FUZZYCD_MODE=non-interactive"
   cd "$basedir"
   rm -f "$FUZZYCD_HISTORY_FILE"
   unset FUZZYCD_MODE
-

--- a/test/approve
+++ b/test/approve
@@ -41,8 +41,10 @@ context "when the shell is interactive"
 
 
 context "when the history file contains some entries"
+
   rm -f "$FUZZYCD_HISTORY_FILE"  
   cd /usr/local/bin > /dev/null
+  cd /usr/local/lib > /dev/null
   cd /etc > /dev/null
   EDITOR="cat"
 
@@ -51,6 +53,15 @@ context "when the history file contains some entries"
 
   describe "cd -e opens the history file"
     approve "cd -e"
+
+  describe "cd -d DIR removes DIR from history"
+    approve "cd -d /etc"
+    approve "cd -s" "cd_s_after_delete"
+
+  describe "cd -d removes current directory from history"
+    cd /usr/local/lib
+    approve "cd -d"
+    approve "cd -s" "cd_s_after_delete2"
 
   cd "$basedir"
   rm -f "$FUZZYCD_HISTORY_FILE"  

--- a/test/approve_setup
+++ b/test/approve_setup
@@ -14,11 +14,11 @@ export FUZZYCD_TTY_FORCE=1
 #   a: source our file directly, which has a bypass via FUZZYCD_TTY_FORCE
 #   b: verify that ~/.bashrc contains the source directive
 #
-source ~/.fuzzy-cd/fuzzy-cd || return 0
+source /usr/local/bin/fuzzycd || return 0
 
 describe "cd is a function"
   [[ "$(type -t cd)" == "function" ]] || fail "Expected function got $(type -t cd)"
 
 describe "~/.bashrc contains the source directive"
-  grep -q .fuzzy-cd/fuzzy-cd ~/.bashrc || fail "Expected to find source directive in ~/.bashrc"
+  grep -q fuzzycd ~/.bashrc || fail "Expected to find source directive in ~/.bashrc"
 

--- a/test/approve_setup
+++ b/test/approve_setup
@@ -14,7 +14,7 @@ export FUZZYCD_TTY_FORCE=1
 #   a: source our file directly, which has a bypass via FUZZYCD_TTY_FORCE
 #   b: verify that ~/.bashrc contains the source directive
 #
-source /usr/local/bin/fuzzycd || return 0
+source /usr/local/bin/fuzzycd
 
 describe "cd is a function"
   [[ "$(type -t cd)" == "function" ]] || fail "Expected function got $(type -t cd)"


### PR DESCRIPTION
- Change history file location to `~/.fuzzy-cd/history` - so we have everything in a single dir
- Add `cd -d [DIR`] command to delete a dir from history - closes #4
- Show supported environment variables in `cd -h`
- Add `FUZZYCD_MODE` environment variable
  - when set to `default` or empty - behave as usual
  - when set to `no-preview` - disable the `ls` preview mane
  - when set to `non-interactive` - never show the fzf menu, always `cd` to the best match
  - closes #7 