### PR TITLE
Add fuzzy bash completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ instantly using a fuzzy match, with or without an interactive menu.
 
 # Fuzzy CD
 
-![Version](https://img.shields.io/badge/version-0.2.3-blue.svg)
+![Version](https://img.shields.io/badge/version-0.2.4-blue.svg)
 [![Build Status](https://github.com/DannyBen/fuzzycd/workflows/Test/badge.svg)](https://github.com/DannyBen/fuzzycd/actions?query=workflow%3ATest)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ instantly using a fuzzy match, with or without an interactive menu.
   - Minimal - cd to best match
   - Interactive
   - Interactive with `ls` preview
+- Optional fuzzy bash completions.
 
 ## Prerequisites
 
@@ -61,9 +62,6 @@ You are encouraged to inspect the [setup script](setup) before running.
 
   ```
   $ cd -h
-
-  fuzzycd 0.2.3
-
   Usage:
     cd DIR       change working directory
     cd SEARCH    change working directory or show selection menu
@@ -71,6 +69,7 @@ You are encouraged to inspect the [setup script](setup) before running.
     cd -e        edit history file
     cd -s        show history file
     cd -d [DIR]  delete current or specified directory from history
+    cd -c        show completions function [usage: eval "$(cd -c)"]
     cd -v        show version
     cd -h        show this help
 
@@ -83,6 +82,10 @@ You are encouraged to inspect the [setup script](setup) before running.
         m = minimal, non interactive, always cd to best match (default)
         i = interactive when needed, no preview
         p = interactive when needed, with ls preview
+
+    FUZZYCD_COMPLETIONS_COUNT
+      Maximum number of suggestions to show in bash completions
+      (default: 10)
 
   Interactive Keyboard Bindings:
     Del
@@ -119,10 +122,25 @@ matching directories when running in interactive mode, or you will
 `cd` to the best match when running in non-interactive mode (default).
 
 
+## Bash completions
+
+To enable fuzzy bash completions, add the following line to your `~/.bashrc`:
+
+```bash
+eval "$(cd -c)"
+```
+
+This works best when tab completion is configured for inline completions, which
+you can set by adding/updating the `~/.inputrc` file:
+
+```bash
+# ~/.inputrc
+TAB: menu-complete
+```
+
 ## Uninstall
 
-1. Remove the `source /usr/local/bin/fuzzycd` line from your startup script(s)
-   (`~/.bashrc` and/or `~/.zshrc`).
+1. Remove the `source /usr/local/bin/fuzzycd` line from your `~/.bashrc`.
 2. Delete `/usr/local/bin/fuzzycd`.
 3. Optionally, delete the history file (`~/.fuzzycd-history`).
 4. Retsrat your session.

--- a/fuzzycd
+++ b/fuzzycd
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 fuzzycd_run() {
-  local version="0.2.3"
+  local version="0.2.4"
   local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}
 
   _fzcd_is_dirname() {

--- a/fuzzycd
+++ b/fuzzycd
@@ -126,6 +126,7 @@ fuzzycd_run() {
     echo "    Delete selected directory from history"
   }
 
+  # shellcheck disable=SC2016
   _fzcd_show_completions() {
     echo '_fuzzycd_completions() {'
     echo '  local cur=${COMP_WORDS[COMP_CWORD]}'

--- a/fuzzycd
+++ b/fuzzycd
@@ -121,6 +121,10 @@ fuzzycd_run() {
     echo "      i = interactive when needed, no preview"
     echo "      p = interactive when needed, with ls preview"
     echo ""
+    echo "  FUZZYCD_COMPLETIONS_COUNT"
+    echo "    Maximum number of suggestions to show in bash completions"
+    echo "    (default: 10)"
+    echo ""
     echo "Interactive Keyboard Bindings:"
     echo "  Del"
     echo "    Delete selected directory from history"
@@ -131,9 +135,10 @@ fuzzycd_run() {
     echo '_fuzzycd_completions() {'
     echo '  local cur=${COMP_WORDS[COMP_CWORD]}'
     echo '  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}'
+    echo '  local count=${FUZZYCD_COMPLETIONS_COUNT:-10}'
     echo '  _cd' # invoke original completions
     echo '  [[ $cur =~ ^(/|\.) ]] && return'
-    echo '  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile") )'
+    echo '  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile" | head -n$count) )'
     echo '}'
     echo 'complete -o nosort -F _fuzzycd_completions cd'
   }

--- a/fuzzycd
+++ b/fuzzycd
@@ -107,6 +107,7 @@ fuzzycd_run() {
     echo "  cd -e        edit history file"
     echo "  cd -s        show history file"
     echo "  cd -d [DIR]  delete current or specified directory from history"
+    echo "  cd -c        show completions function [usage: eval \"\$(cd -c)\"]"
     echo "  cd -v        show version"
     echo "  cd -h        show this help"
     echo ""
@@ -123,6 +124,17 @@ fuzzycd_run() {
     echo "Interactive Keyboard Bindings:"
     echo "  Del"
     echo "    Delete selected directory from history"
+  }
+
+  _fzcd_show_completions() {
+    echo '_fuzzycd_completions() {'
+    echo '  local cur=${COMP_WORDS[COMP_CWORD]}'
+    echo '  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}'
+    echo '  _cd' # invoke original completions
+    echo '  [[ $cur =~ ^(/|\.) ]] && return'
+    echo '  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile") )'
+    echo '}'
+    echo 'complete -o nosort -F _fuzzycd_completions cd'
   }
 
   _fzcd_handle_command() {
@@ -143,6 +155,7 @@ fuzzycd_run() {
       "-v") _fzcd_show_version ;;
       "-e") _fzcd_edit_histfile ;;
       "-s") _fzcd_show_histfile ;;
+      "-c") _fzcd_show_completions ;;
       "-d")
         shift
         _fzcd_delete_dir "$@"

--- a/op.conf
+++ b/op.conf
@@ -1,3 +1,4 @@
 shellcheck: shellcheck setup fuzzycd && echo PASS
 shfmt: shfmt -d -i 2 -ci setup fuzzycd && echo PASS
+codespell: codespell
 test: test/approve

--- a/test/approvals/cd_c
+++ b/test/approvals/cd_c
@@ -1,8 +1,9 @@
 _fuzzycd_completions() {
   local cur=${COMP_WORDS[COMP_CWORD]}
   local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}
+  local count=${FUZZYCD_COMPLETIONS_COUNT:-10}
   _cd
   [[ $cur =~ ^(/|\.) ]] && return
-  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile") )
+  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile" | head -n$count) )
 }
 complete -o nosort -F _fuzzycd_completions cd

--- a/test/approvals/cd_c
+++ b/test/approvals/cd_c
@@ -1,0 +1,8 @@
+_fuzzycd_completions() {
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local histfile=${FUZZYCD_HISTORY_FILE:-"$HOME/.fuzzycd-history"}
+  _cd
+  [[ $cur =~ ^(/|\.) ]] && return
+  COMPREPLY+=( $(fzf --filter "$cur" --exit-0 <"$histfile") )
+}
+complete -o nosort -F _fuzzycd_completions cd

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -1,4 +1,4 @@
-fuzzycd 0.2.3
+fuzzycd 0.2.4
 
 Usage:
   cd DIR       change working directory

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -7,6 +7,7 @@ Usage:
   cd -e        edit history file
   cd -s        show history file
   cd -d [DIR]  delete current or specified directory from history
+  cd -c        show completions function [usage: eval "$(cd -c)"]
   cd -v        show version
   cd -h        show this help
 

--- a/test/approvals/cd_h
+++ b/test/approvals/cd_h
@@ -21,6 +21,10 @@ Environment Variables:
       i = interactive when needed, no preview
       p = interactive when needed, with ls preview
 
+  FUZZYCD_COMPLETIONS_COUNT
+    Maximum number of suggestions to show in bash completions
+    (default: 10)
+
 Interactive Keyboard Bindings:
   Del
     Delete selected directory from history

--- a/test/approvals/cd_v
+++ b/test/approvals/cd_v
@@ -1,1 +1,1 @@
-fuzzycd 0.2.3
+fuzzycd 0.2.4

--- a/test/approve
+++ b/test/approve
@@ -33,6 +33,10 @@ context "when the shell is interactive"
     it "shows version"
       approve "cd -v"
 
+  describe "cd -c"
+    it "shows completions function"
+      approve "cd -c"
+
   describe "cd DIR"
     it "adds it to history"
       cd tmp/one/two > /dev/null


### PR DESCRIPTION
This PR adds fuzzy bash completions to the `cd` command.

1. The new `cd -c` command outputs a short completions function
2. To install it, simply call `eval "$(cd -c)"` in the current session, or in `~/.bashrc` 
3. Type `cd some-fuzzy-search<TAB>` to see the result.
4. The suggestions are sorted by the same `fzf` priority.

This is particularly useful when tab completions are configured to instantly complete the line. To do so, add the below lines to `~/.inputrc` (create the file if needed).

```bash
# ~/.inputrc
# Change tab behavior and add shift tab for old behavior
TAB: menu-complete
"\e[Z": complete
```

